### PR TITLE
add precompile flag to build

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,7 +5,8 @@ open Lake DSL
 package Blake3
 
 @[default_target]
-lean_lib Blake3
+lean_lib Blake3 where
+  precompileModules := true
 
 @[test_driver]
 lean_exe Blake3Test


### PR DESCRIPTION
This lets us do

```
#eval Address.blake3 ⟨#[0]⟩
```

without erroring on

```
Could not find native implementation of external declaration 'Blake3.Hasher.init' (symbols 'l_Blake3_Hasher_init___boxed' or 'l_Blake3_Hasher_init').
For declarations from `Init`, `Std`, or `Lean`, you need to set `supportInterpreter := true` in the relevant `lean_exe` statement in your `lakefile.lean`
```