### PR TITLE
chore: Fix build for downstream Cargo workspaces

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,3 +1,7 @@
+# Declare our own workspace so Cargo doesn't auto-include this crate in a
+# downstream workspace when Lake materializes the package under `.lake/`.
+[workspace]
+
 [package]
 name = "blake3-rs"
 version = "0.1.0"


### PR DESCRIPTION
Fixes an issue where a downstream Lake project that contains a `Cargo.toml` workspace would error when trying to build the `Blake3.lean` dependency:
```
error: current package believes it's in a workspace when it's not:
current:   /path/to/downstream/.lake/packages/Blake3/rust/Cargo.toml
workspace: /path/to/downstream/Cargo.toml

this may be fixable by adding `.lake/packages/Blake3/rust` to the `workspace.members`
array of the manifest located at: /path/to/downstream/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude`
array, or add an empty `[workspace]` table to the package's manifest.
```

This is because the Blake3 Rust crate walks up the `.lake` directory tree until it finds a workspace, which it doesn't find when imported into non-workspace projects. This PR opts for the empty `[workspace]` solution so each consumer doesn't have to do the workaround.
