### PR TITLE
fix: avoid case-insensitive source directory collision

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -15,7 +15,7 @@ abbrev blake3RepoURL := "https://github.com/BLAKE3-team/BLAKE3"
 abbrev blake3RepoTag := "1.8.4"
 
 target cloneBlake3 pkg : GitRepo := do
-  let repoDir : GitRepo := pkg.dir / "blake3"
+  let repoDir : GitRepo := pkg.dir / "blake3-source"
 
   -- Clone if it hasn't already been cloned
   let alreadyCloned ← repoDir.dir.pathExists


### PR DESCRIPTION
On case-insensitive filesystems, the Lean module directory `Blake3/` and the cloned C source directory `blake3/` resolve to the same path. Downstream Lake builds on macOS and Windows can therefore remove or overwrite the Lean sources while materializing the C implementation.

Clone the upstream BLAKE3 sources into `blake3-source/` instead. This keeps the existing build and API unchanged while allowing both directories to coexist.

Tested with:
- `lake test`
- a downstream Lean 4.32.2 native matrix on Linux x86_64/ARM64, macOS x86_64/ARM64, and Windows x86_64