### PR TITLE
make precompileModules opt-in via `precompile` option

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,8 +4,15 @@ open Lake DSL
 
 package Blake3
 
+/- Passing the `precompile` option (e.g. `options = {precompile = "on"}` on the
+downstream `[[require]]`, or `with NameMap.empty.insert `precompile "on"` in a
+`lakefile.lean` require) precompiles these libs so the C/Rust FFI symbols are
+auto-loaded into elaborating processes (batch builds and language-server
+workers) — needed by consumers that call Blake3 in `#eval` at elaboration
+time. Off by default: without the option, behavior is unchanged. -/
 @[default_target]
-lean_lib Blake3
+lean_lib Blake3 where
+  precompileModules := (get_config? precompile).isSome
 
 @[test_driver]
 lean_exe Blake3Test
@@ -78,6 +85,7 @@ target blake3_c pkg : System.FilePath := do
   buildStaticLib (pkg.staticLibDir / name) oFileJobs
 
 lean_lib Blake3C where
+  precompileModules := (get_config? precompile).isSome
   roots := #[`Blake3.C]
   moreLinkObjs := #[blake3_c]
 
@@ -88,6 +96,7 @@ target blake3_rs pkg : System.FilePath := do
   inputBinFile $ pkg.dir / "rust" / "target" / "release" / libName
 
 lean_lib Blake3Rust where
+  precompileModules := (get_config? precompile).isSome
   roots := #[`Blake3.Rust]
   moreLinkObjs := #[blake3_rs]
 


### PR DESCRIPTION
Consumers that call Blake3 inside `#eval` at elaboration time — e.g. Verso
blog posts with executable code examples — need the FFI symbols loaded into
the elaborating process, both in batch `lake build` and in language-server
file workers. Without that, the interpreter fails with `Could not find native
implementation of external declaration 'Blake3.C.hasherInit'`, and there is
no reliable way to fix this purely from the consumer side (`--load-dynlib`
via `moreGlobalServerArgs` crash-loops LSP workers, and module-level dynlibs
don't bundle `moreLinkObjs` objects).

Lake's mechanism for this is `precompileModules`: the lib's shared library —
which *does* bundle the `moreLinkObjs` native objects — is built and
automatically loaded for importers, in batch builds via injected
`--load-dynlib` and in the language server via `lake setup-file`'s
`dynlibs`/`plugins`. This is the same pattern MD4Lean uses for its md4c FFI.

Rather than forcing the native-compile cost on every consumer, this PR gates
it behind a require option, **off by default** — with no option passed,
`get_config? precompile` is `none` and behavior is byte-identical to today
(ix unaffected). Consumers opt in with:

```toml
[[require]]
name = "Blake3"
git = "https://github.com/argumentcomputer/Blake3.lean"
rev = "..."
options = {precompile = "on"}
```

or in a `lakefile.lean`:

```lean
require Blake3 from git "..." @ "..."
  with NameMap.empty.insert `precompile "on"
```

The option is applied to all three libs (`Blake3`, `Blake3C`, `Blake3Rust`)
for symmetry; only libs a consumer actually builds/imports are affected.

Validated end-to-end in `argument-website` (with this exact `get_config?`
gating applied to the dependency checkout): `lake setup-file` on a post
importing `Blake3.C` lists `libBlake3_Blake3C.so`/`libBlake3_Blake3.so` for
editor workers, and a scripted LSP session evaluating `#eval Blake3.C.hash …`
live produces correct digests with zero missing-native errors.

Note for consumers: require `options` take effect at dependency
**materialization**, so run `lake update Blake3` after adding them — a plain
rebuild is not enough. (Lake also silently ignores unknown require keys in
TOML, so a typo in `options` fails without a diagnostic.)
